### PR TITLE
Add aditional ssh_config options

### DIFF
--- a/openstack/openstack_vm.yaml
+++ b/openstack/openstack_vm.yaml
@@ -29,7 +29,12 @@ node_types:
         type: string 
       username:  
         description: Username for SSH connection 
-        type: string   
+        type: string
+      ssh_config:
+        description: Additional ssh config, to be added to default ansible_ssh_common_args
+        type: map
+        required: false
+        default: {}
       include_exporter:
         description: Flag to include exporter
         type: boolean
@@ -86,9 +91,10 @@ node_types:
               security_groups:          { type: string,  default: { get_property: [ SELF, security_groups ] } } 
               vm_name:                  { type: string,  default: { get_property: [ SELF, name ] } } 
               ansible_user:             { type: string,  default: { get_property: [ SELF, username ] } } 
-              include_exporter:         { type: boolean, default: { get_property: [ SELF, include_exporter ] } } 
+              ssh_config:               { type: string,  default: { get_property: [ SELF, ssh_config ] } }
+              include_exporter:         { type: boolean, default: { get_property: [ SELF, include_exporter ] } }
               timeout:                  { type: integer, default: { get_property: [ SELF, timeout ] } } 
-              floating_ip_pools:        { type: list,  default: { get_property: [ SELF, floating_ip_pools ] } } 
+              floating_ip_pools:        { type: list,    default: { get_property: [ SELF, floating_ip_pools ] } }
               userdata:                 { type: string,  default: { get_property: [ SELF, userdata ] } } 
               env:                      { type: map,     default: { get_property: [ SELF, env ] } } 
             implementation: 

--- a/openstack/playbooks/vm_create.yml
+++ b/openstack/playbooks/vm_create.yml
@@ -12,7 +12,15 @@
   tasks:
     - set_fact:
         os_env: "{{ env.os_env }}"
-      when: env.os_env is defined  
+      when: env.os_env is defined
+
+    - set_fact:
+        additional_ssh_args: "{{ '-o ' +
+                                ssh_config.keys()|
+                                zip(ssh_config.values())|
+                                map('join', '=')|
+                                join(' -o ') }}"
+      when: ssh_config is defined
 
     - name: Create VM
       os_server:
@@ -48,6 +56,7 @@
           -o BatchMode=yes
           -o UserKnownHostsFile=/dev/null
           -o StrictHostKeyChecking=no
+          {{ additional_ssh_args | default("") }}
 
 
 - hosts: vms


### PR DESCRIPTION
After new Openstack VM is created, it is added to ansible_inventory as the new host. When adding, SODALITE modules use default four ssh config args:
 https://github.com/SODALITE-EU/iac-modules/blob/677fe81b7f905bf5625d61e4951c338acb7f8686/openstack/playbooks/vm_create.yml#L47-L50

This PR enables user, to specify additional [ssh config options](https://linux.die.net/man/5/ssh_config).

It was developed to add IdentityFile parameter when used with Jenkins, but can be used with any other combination of [ssh config options](https://linux.die.net/man/5/ssh_config) as well.


```yaml
sodalite-vm:
      type: sodalite.nodes.OpenStack.VM
      properties:
        name: test-identity-file
        key_name: jenkins-opera
        image: "centos-7 x86_64"
        network: xlab
        security_groups: default,remote_access
        flavor: m1.medium
        ssh_config:
          IdentityFile: ~/.ssh/jenkins-opera
        username: centos
```