### PR TITLE
docker_registry server certs 

### DIFF
--- a/docker/docker_certificate.yaml
+++ b/docker/docker_certificate.yaml
@@ -4,6 +4,7 @@ node_types:
 
   sodalite.nodes.RegistryCertificate:
     derived_from: tosca.nodes.SoftwareComponent
+    description: TLS certificates, that enable docker client to connect with Docker Registry
     properties:
       registry_ip:
         type: string
@@ -43,4 +44,69 @@ node_types:
             inputs:
               registry_ip:              { type: string, default: { get_property: [ SELF, registry_ip ] } }
             implementation:
-              primary: playbooks/remove_cert.yml 
+              primary: playbooks/remove_cert.yml
+
+  sodalite.nodes.RegistryServerCertificate:
+    derived_from: tosca.nodes.SoftwareComponent
+    description: TLS certificates for Docker Registry server.
+    properties:
+      country_name:
+        type: string
+        description: Country name field of the certificate signing request subject.
+        required: true
+      organization_name:
+        type: string
+        description: The organizationName field of the certificate signing request subject.
+        required: true
+      email_address:
+        type: string
+        description: The emailAddress field of the certificate signing request subject.
+        required: true
+      cert_ipv4_address:
+        type: string
+        description: IP to be written to Subject Alternative Name (SAN). If missing, SAN will be set to host's public_address
+        required: false
+        default: ""
+      cert_path:
+        type: string
+        description: Path where required files are stored.
+        required: true
+      # This parameter is supposed to be here until opera enables intrinsic functions on all depths
+      cert_files_prefix:
+        type: string
+        description: Filename of certs. If missing, it will be set to common_name.
+        required: false
+        default: ""
+      domain_name:
+        type: string
+        description: Domain name of server. If missing, it will be set to IP. This will be mapped to 'Common name'.
+        required: false
+        default: ""
+    attributes:
+      cert_files_prefix:
+        type: string
+        description: Certificate filename prefix. Full cert path is [cert_path]/[cert_files_prefix].crt
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            inputs:
+              country_name:                   { type: string, default: { get_property: [ SELF, country_name ] } }
+              organization_name:              { type: string, default: { get_property: [ SELF, organization_name ] } }
+              email_address:                  { type: string, default: { get_property: [ SELF, email_address ] } }
+              cert_ipv4_address:              { type: string, default: { get_property: [ SELF, cert_ipv4_address ] } }
+              public_ipv4_address:            { type: string, default: { get_attribute: [ SELF, host, public_address ] } }
+              cert_path:                      { type: string, default: { get_property: [ SELF, cert_path ] } }
+              cert_files_prefix:              { type: string, default: { get_property: [ SELF, cert_files_prefix ] } }
+              domain_name:                    { type: string, default: { get_property: [ SELF, domain_name ] } }
+            implementation:
+              primary: playbooks/add_registry_server_cert.yml
+              dependencies:
+                - artifacts/ca.crt
+                - artifacts/ca.key
+          delete:
+            inputs:
+              cert_path: { type: string, default: { get_attribute: [ SELF, cert_path ] } }
+            implementation:
+              primary: playbooks/remove_registry_server_cert.yml

--- a/docker/playbooks/add_registry_server_cert.yml
+++ b/docker/playbooks/add_registry_server_cert.yml
@@ -1,0 +1,94 @@
+---
+- hosts: all
+  become_user: root
+  become: yes
+
+  vars:
+    pip_install_packages:
+      - name: cryptography
+
+  pre_tasks:
+    - name: Set vars for Cent OS backward compatibility
+      set_fact:
+        pip_package: python-pip
+      when: ansible_distribution == "CentOS"
+
+  tasks:
+    - set_fact:
+        alt_name: "IP:{{ cert_ipv4_address | default(public_ipv4_address) }}"
+        common_name: "{{ domain_name | default(public_ipv4_address) }}"
+        cert_filename: "{{ cert_files_prefix | default(common_name) }}"
+
+    - debug:
+        msg: {
+               "alt_name": "{{ alt_name }}",
+               "common_name": "{{ common_name }}",
+               "cert_filename":  "{{ cert_filename }}"
+        }
+
+    - name: Create fresh certs dir
+      block:
+        - file:
+            path: "{{ cert_path }}"
+            state: absent
+        - file:
+            path: "{{ cert_path }}"
+            state: directory
+
+    - name: Copy root CA files
+      block:
+        - copy:
+            src: ca.crt
+            dest: "{{ cert_path }}/ca.crt"
+        - copy:
+            src: ca.key
+            dest: "{{ cert_path }}/ca.key"
+
+    - name: Install root CA
+      block:
+        - command: "cp {{ cert_path }}/ca.crt /etc/pki/ca-trust/source/anchors/ca.crt"
+        - command: update-ca-trust
+      when: ansible_distribution == "CentOS"  
+
+    - name: Install root CA
+      block:
+        - file:
+            path: "/usr/local/share/ca-certificates/opera"
+            state: directory
+        - command: "cp {{ cert_path }}/ca.crt /usr/local/share/ca-certificates/opera/ca.crt"
+        - command: update-ca-certificates
+      when: ansible_distribution == "Ubuntu"        
+
+    - name: Generate certificates and clean up
+      block:
+        - openssl_privatekey:
+            path: "{{ cert_path }}/{{ common_name }}.key"
+            size: 4096
+        - openssl_csr:
+            path: "{{ cert_path }}/{{ common_name}}.csr"
+            privatekey_path: "{{ cert_path }}/{{ common_name}}.key"
+            country_name: "{{ country_name }}"
+            organization_name: "{{ organization_name }}"
+            email_address:  "{{ email_address }}"
+            common_name: "{{ common_name}}"
+            subject_alt_name: "{{ alt_name }}"
+        - openssl_certificate:
+            path: "{{ cert_path }}/{{ common_name }}.crt"
+            csr_path: "{{ cert_path }}/{{ common_name }}.csr"
+            ownca_path: "{{ cert_path }}/ca.crt"
+            ownca_privatekey_path: "{{ cert_path }}/ca.key"
+            provider: "ownca"
+        - file:
+            state: absent
+            path: "{{ cert_path }}/{{ common_name}}.csr"
+        - file:
+            state: absent
+            path: "{{ cert_path }}/ca.key"
+
+    - name: Set attributes
+      set_stats:
+        data:
+          cert_files_prefix: "{{ common_name }}"
+
+  roles:
+    - role: geerlingguy.pip

--- a/docker/playbooks/add_registry_server_cert.yml
+++ b/docker/playbooks/add_registry_server_cert.yml
@@ -15,16 +15,10 @@
 
   tasks:
     - set_fact:
-        alt_name: "IP:{{ cert_ipv4_address | default(public_ipv4_address) }}"
-        common_name: "{{ domain_name | default(public_ipv4_address) }}"
-        cert_filename: "{{ cert_files_prefix | default(common_name) }}"
-
-    - debug:
-        msg: {
-               "alt_name": "{{ alt_name }}",
-               "common_name": "{{ common_name }}",
-               "cert_filename":  "{{ cert_filename }}"
-        }
+        alt_name: "IP:{{ cert_ipv4_address | default(public_ipv4_address, true) }}"
+        common_name: "{{ domain_name | default(public_ipv4_address, true) }}"
+    - set_fact:
+        cert_filename: "{{ cert_files_prefix | default(common_name, true) }}"
 
     - name: Create fresh certs dir
       block:
@@ -62,25 +56,25 @@
     - name: Generate certificates and clean up
       block:
         - openssl_privatekey:
-            path: "{{ cert_path }}/{{ common_name }}.key"
+            path: "{{ cert_path }}/{{ cert_filename }}.key"
             size: 4096
         - openssl_csr:
-            path: "{{ cert_path }}/{{ common_name}}.csr"
-            privatekey_path: "{{ cert_path }}/{{ common_name}}.key"
+            path: "{{ cert_path }}/{{ cert_filename}}.csr"
+            privatekey_path: "{{ cert_path }}/{{ cert_filename}}.key"
             country_name: "{{ country_name }}"
             organization_name: "{{ organization_name }}"
             email_address:  "{{ email_address }}"
             common_name: "{{ common_name}}"
             subject_alt_name: "{{ alt_name }}"
         - openssl_certificate:
-            path: "{{ cert_path }}/{{ common_name }}.crt"
-            csr_path: "{{ cert_path }}/{{ common_name }}.csr"
+            path: "{{ cert_path }}/{{ cert_filename }}.crt"
+            csr_path: "{{ cert_path }}/{{ cert_filename }}.csr"
             ownca_path: "{{ cert_path }}/ca.crt"
             ownca_privatekey_path: "{{ cert_path }}/ca.key"
             provider: "ownca"
         - file:
             state: absent
-            path: "{{ cert_path }}/{{ common_name}}.csr"
+            path: "{{ cert_path }}/{{ cert_filename }}.csr"
         - file:
             state: absent
             path: "{{ cert_path }}/ca.key"
@@ -88,7 +82,7 @@
     - name: Set attributes
       set_stats:
         data:
-          cert_files_prefix: "{{ common_name }}"
+          cert_files_prefix: "{{ cert_filename }}"
 
   roles:
     - role: geerlingguy.pip

--- a/docker/playbooks/remove_registry_server_cert.yml
+++ b/docker/playbooks/remove_registry_server_cert.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  become_user: root
+  become: yes
+
+  vars:
+    pip_install_packages:
+      - name: cryptography
+        state: absent
+
+  tasks:
+    - name: Delete the path to certs
+      file:
+          path: "{{ cert_path }}"
+          state: absent
+
+  roles:
+    - geerlingguy.pip


### PR DESCRIPTION
TOSCA node `sodalite.nodes.RegistryServerCertificate` is specifically designed to generate server TLS certs for private deployment of Docker Registry.