### PR TITLE
Fix cryptography installation on ubuntu

### DIFF
--- a/docker/playbooks/add_cert.yml
+++ b/docker/playbooks/add_cert.yml
@@ -6,6 +6,8 @@
   vars:
     centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
+      - name: pip
+        state: latest
       - name: cryptography
 
   pre_tasks:
@@ -88,4 +90,6 @@
             path: "{{ cert_path }}/ca.key"
 
   roles:
+    - role: geerlingguy.repo-epel
+      when: ansible_distribution == "CentOS"
     - role: geerlingguy.pip

--- a/docker/playbooks/add_cert.yml
+++ b/docker/playbooks/add_cert.yml
@@ -4,15 +4,18 @@
   become: yes
 
   vars:
+    centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
       - name: cryptography
-        version: "3.3"
 
   pre_tasks:
     - name: Set vars for Cent OS backward compatibility
       set_fact:
         pip_package: python-pip
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+        pip_install_packages:
+          - name: cryptography
+            version: "3.3"
+      when: centos7
 
   tasks:
     - set_fact:

--- a/docker/playbooks/add_registry_server_cert.yml
+++ b/docker/playbooks/add_registry_server_cert.yml
@@ -6,6 +6,8 @@
   vars:
     centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
+      - name: pip
+        state: latest
       - name: cryptography
 
   pre_tasks:
@@ -89,4 +91,6 @@
           cert_files_prefix: "{{ cert_filename }}"
 
   roles:
+    - role: geerlingguy.repo-epel
+      when: ansible_distribution == "CentOS"
     - role: geerlingguy.pip

--- a/docker/playbooks/add_registry_server_cert.yml
+++ b/docker/playbooks/add_registry_server_cert.yml
@@ -4,15 +4,18 @@
   become: yes
 
   vars:
+    centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
       - name: cryptography
-        version: "3.3"
 
   pre_tasks:
     - name: Set vars for Cent OS backward compatibility
       set_fact:
         pip_package: python-pip
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+        pip_install_packages:
+          - name: cryptography
+            version: "3.3"
+      when: centos7
 
   tasks:
     - set_fact:

--- a/docker/playbooks/create_docker_host.yml
+++ b/docker/playbooks/create_docker_host.yml
@@ -4,6 +4,7 @@
   become: yes
 
   vars:
+    centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
       - name: docker
     
@@ -15,7 +16,7 @@
       set_fact:
         docker_package: "docker-ce-19.03.5-3.el7"
         pip_package: python-pip
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+      when: centos7
 
   tasks:
     - name: Set attributes

--- a/misc/ssh/playbooks/create.yml
+++ b/misc/ssh/playbooks/create.yml
@@ -5,6 +5,8 @@
   vars:
     centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
+      - name: pip
+        state: latest
       - name: cryptography
       - name: pyOpenSSL
 

--- a/misc/ssh/playbooks/create.yml
+++ b/misc/ssh/playbooks/create.yml
@@ -3,10 +3,20 @@
   become_user: root
   become: yes
   vars:
+    centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
       - name: cryptography
-        version: "3.3"
       - name: pyOpenSSL
+
+    pre_tasks:
+      - name: Set vars for Cent OS backward compatibility
+        set_fact:
+          pip_package: python-pip
+          pip_install_packages:
+            - name: cryptography
+              version: "3.3"
+            - name: pyOpenSSL
+        when: centos7
 
   tasks:
     - name: Generate OpenStack key

--- a/misc/tls/playbooks/create.yml
+++ b/misc/tls/playbooks/create.yml
@@ -6,6 +6,8 @@
   vars:
     centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
+      - name: pip
+        state: latest
       - name: cryptography
 
   pre_tasks:
@@ -96,4 +98,6 @@
           cert_files_prefix: "{{ common_name}}"
 
   roles:
+    - role: geerlingguy.repo-epel
+      when: ansible_distribution == "CentOS"
     - role: geerlingguy.pip

--- a/misc/tls/playbooks/create.yml
+++ b/misc/tls/playbooks/create.yml
@@ -4,15 +4,18 @@
   become: yes
 
   vars:
+    centos7: "{{ ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' }}"
     pip_install_packages:
       - name: cryptography
-        version: "3.3"
 
   pre_tasks:
     - name: Set vars for Cent OS backward compatibility
       set_fact:
         pip_package: python-pip
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+        pip_install_packages:
+          - name: cryptography
+            version: "3.3"
+      when: centos7
 
   tasks:
     - set_fact:


### PR DESCRIPTION
In order for the deployment to not fail on centos7, cryptography package has been pinned to 3.4, however, ubuntu (and probably other distributions) need the latest version since 3.4 causes incompatibilities with OpenSSL (SODALITE-EU/iac-platform-stack#28)

This PR does two things:
- upgrades pip (for non-centos7 distros)
- pins cryptography to 3.4 (ONLY on centos7)