### PR TITLE
Add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# iac-modules
-This repository contains the TOSCA modules for SODALITE deployment blueprints 
+# SODALITE IaC Modules
+This repository contains the TOSCA modules for SODALITE deployment blueprints.
+
+## Requirements
+SODALITE IaC (Infrastructure as Code) Modules need ansible roles. They can be installed with following command:
+```shell script
+ansible-galaxy install -r requirements.yml --force
+```

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,8 @@
+roles:
+  # Install a roles from Ansible Galaxy.
+  - src: geerlingguy.docker
+    version: 3.0.0
+  - src: geerlingguy.pip
+    version: 2.0.0
+  - src: geerlingguy.repo-epel
+    version: 3.0.0


### PR DESCRIPTION
Since some modules need certain ansible roles to execute properly, it would be a good thing to provide a way to install them.

It would also simplify dependency installation for blueprints that use IaC Modules.
In the current state, every blueprint needs to have its own requirements file (or list of command) for the installation of roles, which are actually required by modules:

```shell script
ansible-galaxy install geerlingguy.pip,2.0.0 --force
ansible-galaxy install geerlingguy.docker,3.0.0 --force
ansible-galaxy install geerlingguy.repo-epel,3.0.0 --force
git clone -b 3.2.3 https://github.com/SODALITE-EU/iac-modules.git modules/
```
With the proposed solution, the code block above could be simplified:
```shell script
git clone -b 3.2.3 https://github.com/SODALITE-EU/iac-modules.git modules/
ansible-galaxy install -r modules/requirements.yml --force
```

This PR adds a requrements.yml file with documentation on how to install it.

