### PR TITLE
Added node type for monitoring rules registration

### DIFF
--- a/misc/rules/artifacts/ruleset.yml.j2
+++ b/misc/rules/artifacts/ruleset.yml.j2
@@ -2,12 +2,12 @@ groups:
 - name: alert.rules
   rules:
   {% for rule in ruleset %}
-  - alert: {{rule.name}}
-      expr: {{rule.expr }}
+  - alert: {{ rule.name }}
+      expr: {{ rule.expr }}
       for: {{ rule.for }}
       labels:
         severity: warning
       annotations:
-        summary: '{{rule.summary}} (instance {{'{{'}} $labels.instance {{'}}'}})'
-        description: '{{rule.desc}}\n   VALUE = {{'{{'}} $value {{'}}'}}\n  LABELS: {{'{{'}} $labels {{'}}'}}'
+        summary: '{{ rule.summary }} (instance {{'{{'}} $labels.instance {{'}}'}})'
+        description: '{{ rule.desc }}\n   VALUE = {{'{{'}} $value {{'}}'}}\n  LABELS: {{'{{'}} $labels {{'}}'}}'
   {% endfor %}

--- a/misc/rules/artifacts/ruleset.yml.j2
+++ b/misc/rules/artifacts/ruleset.yml.j2
@@ -1,0 +1,13 @@
+groups:
+- name: alert.rules
+  rules:
+  {% for rule in ruleset %}
+  - alert: {{rule.name}}
+      expr: {{rule.expr }}
+      for: {{ rule.for }}
+      labels:
+        severity: warning
+      annotations:
+        summary: '{{rule.summary}} (instance {{'{{'}} $labels.instance {{'}}'}})'
+        description: '{{rule.desc}}\n   VALUE = {{'{{'}} $value {{'}}'}}\n  LABELS: {{'{{'}} $labels {{'}}'}}'
+  {% endfor %}

--- a/misc/rules/playbooks/ruleset_deregister.yml
+++ b/misc/rules/playbooks/ruleset_deregister.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+    
+    - name: Deregister rule file in ruleserver
+      shell: curl http://{{ ruleserver_address|quote }}:9092/rules/remove/{{ ruleset_id }}
+...

--- a/misc/rules/playbooks/ruleset_register.yml
+++ b/misc/rules/playbooks/ruleset_register.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+    - name: Create ruleset file from template 
+      become: yes
+      template:
+        src: "ruleset.yml.j2"
+        dest: "/tmp/ruleset.yml"
+        mode: "0755"
+
+    - name: Register ruleset in ruleserver
+      shell: curl --data-binary @/tmp/ruleset.yml http://{{ ruleserver_address|quote }}:9092/rules/add/{{ ruleset_id }}
+...

--- a/misc/rules/types.yml
+++ b/misc/rules/types.yml
@@ -1,0 +1,40 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  sodalite.nodes.Configuration.ruleset:
+    derived_from: tosca.nodes.SoftwareComponent
+    description: Node for registration/deregistration of the ruleset file
+    properties:
+      ruleset:
+        type: list
+        description: ruleset list with rules to register
+        required: True
+      ruleserver_address:
+        type: string
+        description: IP address of the ruleserver
+        required: True
+      ruleset_id: 
+        type: string
+        description: name of the ruleset to register
+        required: True
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            inputs:
+              ruleset:            { default: { get_property: [ SELF, ruleset ] }, type: string }
+              ruleserver_address: { default: { get_property: [ SELF, ruleserver_address ] }, type: string }
+              ruleset_id:         { default: { get_property: [ SELF, ruleset_id ] }, type: string }
+            implementation:
+              primary: playbooks/ruleset_register.yml
+              dependencies:
+                - artifacts/ruleset.yml.j2
+
+          delete:
+            inputs:
+              ruleserver_address: { default: { get_property: [ SELF, ruleserver_address ] }, type: string }
+              ruleset_id:         { default: { get_property: [ SELF, ruleset_id ] }, type: string }
+            implementation:
+              primary: playbooks/ruleset_deregister.yml
+              

--- a/misc/rules/types.yml
+++ b/misc/rules/types.yml
@@ -1,5 +1,23 @@
 tosca_definitions_version: tosca_simple_yaml_1_3
 
+data_types:
+  sodalite.datatypes.Monitoring.Rule:
+    derived_from: tosca.datatypes.Root
+    properties:
+      name:
+        type: string
+        required: True
+      expr:
+        type: string
+        required: True
+      for:
+        type: string
+        required: True
+      desc:
+        type: string
+      summary:
+        type: string
+
 node_types:
   sodalite.nodes.Configuration.ruleset:
     derived_from: tosca.nodes.SoftwareComponent
@@ -7,8 +25,12 @@ node_types:
     properties:
       ruleset:
         type: list
+        entry_schema:
+          type: sodalite.datatypes.Monitoring.Rule
         description: ruleset list with rules to register
         required: True
+        constraints:
+          - min_length: 1
       ruleserver_address:
         type: string
         description: IP address of the ruleserver

--- a/misc/rules/types.yml
+++ b/misc/rules/types.yml
@@ -15,8 +15,10 @@ data_types:
         required: True
       desc:
         type: string
+        default: ""
       summary:
         type: string
+        default: ""
 
 node_types:
   sodalite.nodes.Configuration.ruleset:


### PR DESCRIPTION
Added a new node type for ruleset file creation and registration with the monitoring stack. 

It needs 3 inputs:

ruleset: list of rules that want to be included in the ruleset, each must contain:

name: name of the rule
expr: PromQL expression for the rule
for: How long the alert must be active uninterrupted for it to trigger
summary: Summary of the rule
desc: Description of the rule

ruleserver_address: IP address of the ruleserver

ruleset_id: ID the ruleset must have when registered with the ruleserver, should be unique.