### PR TITLE
Fix Slurm job state monitoring

### DIFF
--- a/hpc/app/playbooks/workflows/slurm/check_slurm.yml
+++ b/hpc/app/playbooks/workflows/slurm/check_slurm.yml
@@ -13,7 +13,7 @@
   - name: Run continuously scontrol to monitor the status of the job
     shell:  scontrol show job -dd {{ job_id }} | grep -o 'JobState=[A-Z]*'
     register: job_monitor 
-    until: "job_monitor.stdout == 'JobState=COMPLETED'"
+    until: "job_monitor.stdout == 'JobState=COMPLETED' or job_monitor.stdout == 'JobState=FAILED'"
     delay: "{{ monitor_delay_step }}"
     retries: "{{ monitor_retries }}"
     async: "{{ walltime_sec | int }}"

--- a/hpc/app/playbooks/workflows/slurm/start_slurm.yml
+++ b/hpc/app/playbooks/workflows/slurm/start_slurm.yml
@@ -12,9 +12,9 @@
         workspace_path: "{{ workspace_dir_results.stdout }}"
 
     - name: Submit the job
-      shell: sbatch {{ job_name }}.sh
+      shell: sbatch {{ exec_name }}.sh
       args:
-        chdir: "{{ job_workspace_path }}"
+        chdir: "{{ workspace_path }}"
       register: job
       environment: "{{ env if env is defined }}"
 

--- a/hpc/slurm/slurm-job/playbooks/check.yml
+++ b/hpc/slurm/slurm-job/playbooks/check.yml
@@ -33,7 +33,7 @@
     - name: Run continuously scontrol to monitor the status of the job
       shell:  scontrol show job -dd {{ job_id }} | grep -o 'JobState=[A-Z]*'
       register: job_monitor 
-      until: "job_monitor.stdout == 'JobState=COMPLETED'"
+      until: "job_monitor.stdout == 'JobState=COMPLETED' or job_monitor.stdout == 'JobState=FAILED'"
       delay: "{{ monitor_delay_step }}"
       retries: "{{ monitor_retries }}"
       async: "{{ walltime_sec | int }}"


### PR DESCRIPTION
A failed Slurm job causes a playbook to check the job indefinitely, since the "completed" state is never achieved. This PR complements current playbooks for Slurm job state monitoring with additional check for failed job.