### PR TITLE
Fix docker on centos7 and ssh config improvement

### DIFF
--- a/docker/playbooks/create_docker_host.yml
+++ b/docker/playbooks/create_docker_host.yml
@@ -17,6 +17,8 @@
         docker_package: "docker-ce-19.03.5-3.el7"
         pip_package: python-pip
         pip_install_packages:
+          - name: websocket-client
+            version: "0.59.0"
           - name: docker
             version: "4.4.4"
       when: centos7
@@ -36,9 +38,6 @@
         - service:
             name: docker
             state: restarted
-    - name: make ansible fail
-      fail:
-        msg: ooops
 
   roles:
     - role: geerlingguy.repo-epel

--- a/docker/playbooks/create_docker_host.yml
+++ b/docker/playbooks/create_docker_host.yml
@@ -36,6 +36,9 @@
         - service:
             name: docker
             state: restarted
+    - name: make ansible fail
+      fail:
+        msg: ooops
 
   roles:
     - role: geerlingguy.repo-epel

--- a/openstack/playbooks/vm_create.yml
+++ b/openstack/playbooks/vm_create.yml
@@ -54,7 +54,6 @@
         ansible_ssh_common_args: >
           -o IdentitiesOnly=yes
           -o BatchMode=yes
-          -o UserKnownHostsFile=/dev/null
           -o StrictHostKeyChecking=no
           {{ additional_ssh_args | default("") }}
         id: "{{ server_info.server.id }}"


### PR DESCRIPTION
This PR pinns websocket-client to 0.59.0, which is last version to support python <3.
It also removes redundant ssh config option.

Closes #23 