### PR TITLE
Hpc-exporter integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/blueprints/hpc/inputs.yaml

--- a/hpc/app/playbooks/create_collector.yml
+++ b/hpc/app/playbooks/create_collector.yml
@@ -4,31 +4,14 @@
     url: http://{{hpc_exporter_address}}/collector
     method: post
     body: 
-      scheduler": slurm
+      scheduler: {{ "pbs" if (scheduler == "torque") else scheduler }}
       host: {{ ssh_host }}
       deployment_label: {{ deployment_label }}
       monitoring_id: {{ monitoring_id }}
-      hpc_label: {{ hpc_host if (hpc_label == "") else hpc_label }}
+      hpc_label: {{ ssh_host if (hpc_label == "") else hpc_label }}
       scrape_interval: {{ scrape_interval }}
     status_code: 200
     body_format: json
     headers:
       authorization: "Bearer {{ jwt }}"
-  when: scheduler == "slurm"
-
-- name: Call HPC Exporter API to create a PBS collector
-  uri: 
-    url: http://{{hpc_exporter_address}}/collector
-    method: post
-    body: 
-      scheduler": pbs
-      host: {{ ssh_host }}
-      deployment_label: {{ deployment_label }}
-      monitoring_id: {{ monitoring_id }}
-      hpc_label: {{ hpc_host if (hpc_label == "") else hpc_label }}
-      scrape_interval: {{ scrape_interval }}
-    status_code: 200
-    body_format: json
-    headers:
-      authorization: "Bearer {{ jwt }}"
-  when: scheduler == "torque"
+  when: scheduler != "batch"

--- a/hpc/app/playbooks/create_collector.yml
+++ b/hpc/app/playbooks/create_collector.yml
@@ -2,9 +2,9 @@
 - hosts: all
   gather_facts: yes
   tasks:
-  - name: Call HPC Exporter API to create a slurm collector
+  - name: Call HPC Exporter API to create a collector
     uri: 
-      url: http://{{hpc_exporter_address}}/collector
+      url: "{{hpc_exporter_address}}/collector"
       method: post
       body: 
         scheduler: "{{ (scheduler == 'torque') | ternary('pbs', scheduler) }}"

--- a/hpc/app/playbooks/create_collector.yml
+++ b/hpc/app/playbooks/create_collector.yml
@@ -1,17 +1,20 @@
 ---
-- name: Call HPC Exporter API to create a slurm collector
-  uri: 
-    url: http://{{hpc_exporter_address}}/collector
-    method: post
-    body: 
-      scheduler: {{ "pbs" if (scheduler == "torque") else scheduler }}
-      host: {{ ssh_host }}
-      deployment_label: {{ deployment_label }}
-      monitoring_id: {{ monitoring_id }}
-      hpc_label: {{ ssh_host if (hpc_label == "") else hpc_label }}
-      scrape_interval: {{ scrape_interval }}
-    status_code: 200
-    body_format: json
-    headers:
-      authorization: "Bearer {{ jwt }}"
-  when: scheduler != "batch"
+- hosts: all
+  gather_facts: yes
+  tasks:
+  - name: Call HPC Exporter API to create a slurm collector
+    uri: 
+      url: http://{{hpc_exporter_address}}/collector
+      method: post
+      body: 
+        scheduler: "{{ (scheduler == 'torque') | ternary('pbs', scheduler) }}"
+        host: "{{ ssh_host }}"
+        deployment_label: "{{ deployment_label }}"
+        monitoring_id: "{{ monitoring_id }}"
+        hpc_label: "{{ ssh_host if (hpc_label == '') else hpc_label }}"
+        scrape_interval: "{{ scrape_interval }}"
+      status_code: 200
+      body_format: json
+      headers:
+        Authorization: "Bearer {{ jwt }}"
+    when: scheduler != "batch"

--- a/hpc/app/playbooks/create_collector.yml
+++ b/hpc/app/playbooks/create_collector.yml
@@ -1,0 +1,34 @@
+---
+- name: Call HPC Exporter API to create a slurm collector
+  uri: 
+    url: http://{{hpc_exporter_address}}/collector
+    method: post
+    body: 
+      scheduler": slurm
+      host: {{ ssh_host }}
+      deployment_label: {{ deployment_label }}
+      monitoring_id: {{ monitoring_id }}
+      hpc_label: {{ hpc_label }}
+      scrape_interval: {{ scrape_interval }}
+    status_code: 200
+    body_format: json
+    headers:
+      authorization: "Bearer {{ jwt }}"
+  when: scheduler == "slurm"
+
+- name: Call HPC Exporter API to create a PBS collector
+  uri: 
+    url: http://{{hpc_exporter_address}}/collector
+    method: post
+    body: 
+      scheduler": pbs
+      host: {{ ssh_host }}
+      deployment_label: {{ deployment_label }}
+      monitoring_id: {{ monitoring_id }}
+      hpc_label: {{ hpc_label }}
+      scrape_interval: {{ scrape_interval }}
+    status_code: 200
+    body_format: json
+    headers:
+      authorization: "Bearer {{ jwt }}"
+  when: scheduler == "torque"

--- a/hpc/app/playbooks/create_collector.yml
+++ b/hpc/app/playbooks/create_collector.yml
@@ -8,7 +8,7 @@
       host: {{ ssh_host }}
       deployment_label: {{ deployment_label }}
       monitoring_id: {{ monitoring_id }}
-      hpc_label: {{ hpc_label }}
+      hpc_label: {{ hpc_host if (hpc_label == "") else hpc_label }}
       scrape_interval: {{ scrape_interval }}
     status_code: 200
     body_format: json
@@ -25,7 +25,7 @@
       host: {{ ssh_host }}
       deployment_label: {{ deployment_label }}
       monitoring_id: {{ monitoring_id }}
-      hpc_label: {{ hpc_label }}
+      hpc_label: {{ hpc_host if (hpc_label == "") else hpc_label }}
       scrape_interval: {{ scrape_interval }}
     status_code: 200
     body_format: json

--- a/hpc/app/playbooks/delete_collector.yml
+++ b/hpc/app/playbooks/delete_collector.yml
@@ -1,0 +1,12 @@
+---
+- name: Call HPC Exporter API to delete a collector
+  uri: 
+    url: http://{{hpc_exporter_address}}/collector
+    method: delete
+    body: 
+      host: {{ ssh_host }}
+      monitoring_id: {{ monitoring_id }}
+    status_code: 200
+    body_format: json
+    headers:
+      authorization: "Bearer {{ jwt }}"

--- a/hpc/app/playbooks/delete_collector.yml
+++ b/hpc/app/playbooks/delete_collector.yml
@@ -10,3 +10,4 @@
     body_format: json
     headers:
       authorization: "Bearer {{ jwt }}"
+  when: scheduler != "batch"

--- a/hpc/app/playbooks/delete_collector.yml
+++ b/hpc/app/playbooks/delete_collector.yml
@@ -1,13 +1,16 @@
 ---
-- name: Call HPC Exporter API to delete a collector
-  uri: 
-    url: http://{{hpc_exporter_address}}/collector
-    method: delete
-    body: 
-      host: {{ ssh_host }}
-      monitoring_id: {{ monitoring_id }}
-    status_code: 200
-    body_format: json
-    headers:
-      authorization: "Bearer {{ jwt }}"
-  when: scheduler != "batch"
+- hosts: all
+  gather_facts: yes
+  tasks:
+  - name: Call HPC Exporter API to delete a collector
+    uri: 
+      url: http://{{hpc_exporter_address}}/collector
+      method: delete
+      body: 
+        host: "{{ ssh_host }}"
+        monitoring_id: "{{ monitoring_id }}"
+      status_code: 200
+      body_format: json
+      headers:
+        authorization: "Bearer {{ jwt }}"
+    when: scheduler != "batch"

--- a/hpc/app/playbooks/delete_collector.yml
+++ b/hpc/app/playbooks/delete_collector.yml
@@ -4,7 +4,7 @@
   tasks:
   - name: Call HPC Exporter API to delete a collector
     uri: 
-      url: http://{{hpc_exporter_address}}/collector
+      url: "{{hpc_exporter_address}}/collector"
       method: delete
       body: 
         host: "{{ ssh_host }}"

--- a/hpc/app/playbooks/workflows/register_jobid.yml
+++ b/hpc/app/playbooks/workflows/register_jobid.yml
@@ -4,7 +4,7 @@
   tasks:
   - name: Register JobID in the HPC Exporter's collector
     uri:
-      url: http://{{hpc_exporter_address}}/job
+      url: "{{hpc_exporter_address}}/job"
       method: post
       body: 
         job_id: "{{ job_id }}"

--- a/hpc/app/playbooks/workflows/register_jobid.yml
+++ b/hpc/app/playbooks/workflows/register_jobid.yml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  gather_facts: yes
+  tasks:
+  - name: Register JobID in the HPC Exporter's collector
+    uri:
+      url: http://{{hpc_exporter_address}}/job
+      method: post
+      body: 
+        job_id: "{{ job_id }}"
+        host: "{{ ssh_host }}"
+        monitoring_id: "{{ monitoring_id }}"
+      body_format: json
+      status_code: 200
+    delegate_to: localhost
+    delegate_facts: true

--- a/hpc/app/playbooks/workflows/start.yml
+++ b/hpc/app/playbooks/workflows/start.yml
@@ -20,3 +20,4 @@
       host: {{ ssh_host }}
       monitoring_id: {{ monitoring_id }}
     body_format: json
+  when: scheduler != "batch"

--- a/hpc/app/playbooks/workflows/start.yml
+++ b/hpc/app/playbooks/workflows/start.yml
@@ -10,3 +10,13 @@
 - name: Start job in any compute
   import_playbook: start_batch.yml
   when: scheduler == "batch"
+
+- name: Registering job_id in HPC Exporter
+  uri:
+    url: http://{{hpc_exporter_address}}/job
+    method: POST
+    body: 
+      job_id: {{ job_id }}
+      host: {{ ssh_host }}
+      monitoring_id: {{ monitoring_id }}
+    body_format: json

--- a/hpc/app/playbooks/workflows/start.yml
+++ b/hpc/app/playbooks/workflows/start.yml
@@ -11,13 +11,6 @@
   import_playbook: start_batch.yml
   when: scheduler == "batch"
 
-- name: Registering job_id in HPC Exporter
-  uri:
-    url: http://{{hpc_exporter_address}}/job
-    method: POST
-    body: 
-      job_id: {{ job_id }}
-      host: {{ ssh_host }}
-      monitoring_id: {{ monitoring_id }}
-    body_format: json
+- name: Register the job_id in HPC Exporter
+  import_playbook: register_jobid.yml
   when: scheduler != "batch"

--- a/hpc/app/workflows.yml
+++ b/hpc/app/workflows.yml
@@ -29,7 +29,7 @@ node_types:
           start:
             inputs:
               ansible_user: { type: string, default: { get_property: [SELF, host, username] } }
-              ssh_host:     { type: string, default: { get_property: [SELF, host, ssh_host] } }
+              ssh_host:     { type: string, default: { get_attribute: [SELF, host, public_address] } }
               # ansible_ssh_private_key_file: { type: string, default: { get_property: [SELF, host, ssh-key] } }
               scheduler: { type: string, default: { get_property: [SELF, host, scheduler] } }
               exec_name: { type: string, default: { get_attribute: [SELF, execution, exec_name] } }

--- a/hpc/app/workflows.yml
+++ b/hpc/app/workflows.yml
@@ -29,6 +29,7 @@ node_types:
           start:
             inputs:
               ansible_user: { type: string, default: { get_property: [SELF, host, username] } }
+              ssh_host:     { type: string, default: { get_property: [SELF, host, ssh_host] } }
               # ansible_ssh_private_key_file: { type: string, default: { get_property: [SELF, host, ssh-key] } }
               scheduler: { type: string, default: { get_property: [SELF, host, scheduler] } }
               exec_name: { type: string, default: { get_attribute: [SELF, execution, exec_name] } }

--- a/hpc/app/workflows.yml
+++ b/hpc/app/workflows.yml
@@ -28,19 +28,22 @@ node_types:
         operations:  
           start:
             inputs:
-              ansible_user: { type: string, default: { get_property: [SELF, host, username] } }
-              ssh_host:     { type: string, default: { get_attribute: [SELF, host, public_address] } }
-              # ansible_ssh_private_key_file: { type: string, default: { get_property: [SELF, host, ssh-key] } }
-              scheduler: { type: string, default: { get_property: [SELF, host, scheduler] } }
-              exec_name: { type: string, default: { get_attribute: [SELF, execution, exec_name] } }
-              workspace: { type: string, default: { get_property: [SELF, execution, workspace] } }
-              env: { type: map, default: { get_attribute: [SELF, execution, env] } }
+              ansible_user:         { type: string, default: { get_property:  [SELF, host,      username      ] } }
+              scheduler:            { type: string, default: { get_property:  [SELF, host,      scheduler     ] } }
+              workspace:            { type: string, default: { get_property:  [SELF, execution, workspace     ] } }
+              exec_name:            { type: string, default: { get_attribute: [SELF, execution, exec_name     ] } }
+              ssh_host:             { type: string, default: { get_attribute: [SELF, host,      public_address] } }
+              env:                  { type: map,    default: { get_attribute: [SELF, execution, env           ] } }
+              monitoring_id:        { type: string, default: { get_input:      monitoring_id                    } }
+              hpc_exporter_address: { type: string, default: { get_input:      hpc_exporter_address             } }
+            # ansible_ssh_private_key_file: { type: string, default: { get_property: [SELF, host, ssh-key] } }
             implementation: 
               primary: playbooks/workflows/start.yml
               dependencies: 
                 - playbooks/workflows/batch/start_batch.yml
                 - playbooks/workflows/slurm/start_slurm.yml
                 - playbooks/workflows/torque/start_torque.yml
+                - playbooks/workflows/register_jobid.yml
 
   sodalite.nodes.workflow.Result: 
     derived_from: tosca.nodes.SoftwareComponent
@@ -66,13 +69,13 @@ node_types:
         operations:  
           start:
             inputs:
-              ansible_user: { type: string, default: { get_property: [SELF, host, username] } }
-              # ansible_ssh_private_key_file: { type: string, default: { get_property: [SELF, host, ssh-key] } }
-              scheduler: { type: string, default: { get_property: [SELF, host, scheduler] } }
-              job_monitor_period: { type: integer, default: { get_property: [SELF, monitor_period] } }
-              job_monitor_retries_headroom: { type: integer, default: { get_property: [SELF, monitor_retries_headroom] } }
-              job_id: { type: string, default: { get_attribute: [SELF, job, job_id] } }
-              job_walltime: { type: string, default: { get_attribute: [SELF, job, job_walltime] } }
+              ansible_user:                 { type: string,  default: { get_property:  [SELF, host, username          ] } }
+              scheduler:                    { type: string,  default: { get_property:  [SELF, host, scheduler         ] } }
+              job_monitor_period:           { type: integer, default: { get_property:  [SELF, monitor_period          ] } }
+              job_monitor_retries_headroom: { type: integer, default: { get_property:  [SELF, monitor_retries_headroom] } }
+              job_id:                       { type: string,  default: { get_attribute: [SELF, job, job_id             ] } }
+              job_walltime:                 { type: string,  default: { get_attribute: [SELF, job, job_walltime       ] } }
+            # ansible_ssh_private_key_file: { type: string,  default: { get_property:  [SELF, host, ssh-key           ] } }
             implementation: 
               primary: playbooks/workflows/check.yml
               dependencies: 

--- a/hpc/app/workload_managers.yml
+++ b/hpc/app/workload_managers.yml
@@ -36,16 +36,13 @@ node_types:
         type: string
         default: batch
         constraints:
-          - valid_values: [ torque, slurm, batch ]
+          - valid_values: [ torque, pbs, slurm, batch ]
       username:
         type: string
       ssh-key:
         required: false
         type: string
         default: ""
-      ssh_host: 
-        required: true
-        type: string
       hpc_label:
         required: false
         type: string
@@ -66,19 +63,19 @@ node_types:
           start:
             inputs:
               scheduler:            { type: string, default: { get_property: [SELF, scheduler] } }
-              ssh_host:             { type: string, default: { get_property: [SELF, ssh_host] } }
+              ssh_host:             { type: string, default: { get_attribute: [SELF, public_address] } }
               hpc_label:            { type: string, default: { get_property: [SELF, hpc_label] } }
               monitoring_id:        { get_input: monitoring_id }
               deployment_label:     { get_input: deployment_label}
               jwt:                  { get_input: jwt }
               hpc_exporter_address: { get_input: hpc_exporter_address }
             implementation: 
-              primary: playbooks/workflows/create_collector.yml
+              primary: playbooks/create_collector.yml
           delete:
             inputs:
-              ssh_host:             { type: string, default: { get_property: [SELF, ssh_host] } }
+              ssh_host:             { type: string, default: { get_attribute: [SELF, public_address] } }
               monitoring_id:        { get_input: monitoring_id }
               jwt:                  { get_input: jwt }
               hpc_exporter_address: { get_input: hpc_exporter_address }
             implementation: 
-              primary: playbooks/workflows/delete_collector.yml
+              primary: playbooks/delete_collector.yml

--- a/hpc/app/workload_managers.yml
+++ b/hpc/app/workload_managers.yml
@@ -49,7 +49,7 @@ node_types:
       hpc_label:
         required: false
         type: string
-        default: { get_property: [SELF, ssh_host] }
+        default: ""
       scrape_interval:
         required: false
         type: integer

--- a/hpc/app/workload_managers.yml
+++ b/hpc/app/workload_managers.yml
@@ -43,8 +43,40 @@ node_types:
         required: false
         type: string
         default: ""
+      ssh_host: 
+        required: true
+        type: string
+      hpc_label:
+        required: false
+        type: string
+        default: { get_property: [SELF, ssh_host] }
+      scrape_interval:
+        required: false
+        type: integer
+        default: 15
     capabilities:
       resources:
         type: sodalite.capabilities.WM.JobResources
       optimisations:
         type: sodalite.capabilities.OptimisedTarget
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:  
+          start:
+            inputs:
+              scheduler:        { type: string, default: { get_property: [SELF, scheduler] } }
+              ssh_host:         { type: string, default: { get_property: [SELF, ssh_host] } }
+              hpc_label:        { type: string, default: { get_property: [SELF, hpc_label] } }
+              monitoring_id:    { get_input: monitoring_id }
+              deployment_label: { get_input: deployment_label}
+              jwt:              { get_input: jwt }
+            implementation: 
+              primary: playbooks/workflows/create_collector.yml
+          delete:
+            inputs:
+              ssh_host:         { type: string, default: { get_property: [SELF, ssh_host] } }
+              monitoring_id:    { get_input: monitoring_id }
+              jwt:              { get_input: jwt }
+            implementation: 
+              primary: playbooks/workflows/delete_collector.yml

--- a/hpc/app/workload_managers.yml
+++ b/hpc/app/workload_managers.yml
@@ -65,18 +65,20 @@ node_types:
         operations:  
           start:
             inputs:
-              scheduler:        { type: string, default: { get_property: [SELF, scheduler] } }
-              ssh_host:         { type: string, default: { get_property: [SELF, ssh_host] } }
-              hpc_label:        { type: string, default: { get_property: [SELF, hpc_label] } }
-              monitoring_id:    { get_input: monitoring_id }
-              deployment_label: { get_input: deployment_label}
-              jwt:              { get_input: jwt }
+              scheduler:            { type: string, default: { get_property: [SELF, scheduler] } }
+              ssh_host:             { type: string, default: { get_property: [SELF, ssh_host] } }
+              hpc_label:            { type: string, default: { get_property: [SELF, hpc_label] } }
+              monitoring_id:        { get_input: monitoring_id }
+              deployment_label:     { get_input: deployment_label}
+              jwt:                  { get_input: jwt }
+              hpc_exporter_address: { get_input: hpc_exporter_address }
             implementation: 
               primary: playbooks/workflows/create_collector.yml
           delete:
             inputs:
-              ssh_host:         { type: string, default: { get_property: [SELF, ssh_host] } }
-              monitoring_id:    { get_input: monitoring_id }
-              jwt:              { get_input: jwt }
+              ssh_host:             { type: string, default: { get_property: [SELF, ssh_host] } }
+              monitoring_id:        { get_input: monitoring_id }
+              jwt:                  { get_input: jwt }
+              hpc_exporter_address: { get_input: hpc_exporter_address }
             implementation: 
               primary: playbooks/workflows/delete_collector.yml

--- a/hpc/app/workload_managers.yml
+++ b/hpc/app/workload_managers.yml
@@ -62,20 +62,22 @@ node_types:
         operations:  
           start:
             inputs:
-              scheduler:            { type: string, default: { get_property: [SELF, scheduler] } }
-              ssh_host:             { type: string, default: { get_attribute: [SELF, public_address] } }
-              hpc_label:            { type: string, default: { get_property: [SELF, hpc_label] } }
-              monitoring_id:        { get_input: monitoring_id }
-              deployment_label:     { get_input: deployment_label}
-              jwt:                  { get_input: jwt }
-              hpc_exporter_address: { get_input: hpc_exporter_address }
+              scheduler:            { type: string, default: { get_property:  [SELF, scheduler      ] } }
+              hpc_label:            { type: string, default: { get_property:  [SELF, hpc_label      ] } }
+              scrape_interval:      { type: string, default: { get_property:  [SELF, scrape_interval] } }
+              ssh_host:             { type: string, default: { get_attribute: [SELF, public_address ] } }
+              monitoring_id:        { type: string, default: { get_input:      monitoring_id          } }
+              deployment_label:     { type: string, default: { get_input:      deployment_label       } }
+              jwt:                  { type: string, default: { get_input:      jwt                    } }
+              hpc_exporter_address: { type: string, default: { get_input:      hpc_exporter_address   } }
             implementation: 
               primary: playbooks/create_collector.yml
           delete:
             inputs:
+              scheduler:            { type: string, default: { get_property:  [SELF, scheduler     ] } }
               ssh_host:             { type: string, default: { get_attribute: [SELF, public_address] } }
-              monitoring_id:        { get_input: monitoring_id }
-              jwt:                  { get_input: jwt }
-              hpc_exporter_address: { get_input: hpc_exporter_address }
+              monitoring_id:        { type: string, default: { get_input:      monitoring_id         } }
+              jwt:                  { type: string, default: { get_input:      jwt                   } }
+              hpc_exporter_address: { type: string, default: { get_input:      hpc_exporter_address  } }
             implementation: 
               primary: playbooks/delete_collector.yml

--- a/tests/blueprints/hpc/service.yaml
+++ b/tests/blueprints/hpc/service.yaml
@@ -1,0 +1,167 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+imports:
+  - iac-modules/hpc/app/apps.yml
+  - iac-modules/hpc/app/workflows.yml
+
+topology_template:
+
+  inputs:
+  
+    hlrs-frontend-address:
+      type: string
+    hlrs-username:
+      type: string
+    monitoring_id:
+      type: string
+    deployment_label:
+      type: string
+    hpc_exporter_address:
+      type: string
+    jwt:
+      type: string
+
+  node_templates:
+
+### hlrs resources and runtime descriptions
+    hlrs-testbed:
+      type: sodalite.nodes.hpc.WM
+      properties:
+        scheduler: torque
+        username: { get_input: hlrs-username }
+      attributes:
+        public_address: { get_input: hlrs-frontend-address }
+      capabilities:
+        resources:
+          properties:
+            gpus: 5 
+            cpus: 200
+            memory: 650687
+        optimisations:
+          properties:
+            target: hlrs_testbed # same as in modak db
+
+    batch-app-runtime-hpc:
+      type: sodalite.nodes.batch.Container.Runtime
+      properties:
+        runtime: "singularity"
+        images_location: "images"
+        #certs_location: "certs"
+        #private_registry: "77.231.202.207"
+      requirements:
+        - host: hlrs-testbed
+
+### application description
+    batch-app-1:
+      type: sodalite.nodes.batch.Container.Application
+      # optimization: ai_training.tensor_flow # from AADM, comes as JSON-string to IaC Builder
+      properties:
+        app_tag: "batch-app-1"
+        app_type: "python"
+        executable: "python3 resnet/resnet_imagenet_main.py"
+        arguments: "--data_dir=/mnt/nfs/home/karthee/AI/data/tf_records/train/ -batch_size=96 --train_epochs=3 --train_steps=10 --use_synthetic_data=false"
+        container_runtime: "docker://modakopt/modak:tensorflow-2.1-gpu-src" # default container runtime. Might be substituted by IaCBuilder based on optimization
+        # container_runtime: "private://cadt:1.0.0" # default container runtime for private registry. Might be substituted based on optimization
+      requirements:
+        - runtime: batch-app-runtime-hpc
+        - host: hlrs-testbed
+
+    batch-job-1:
+      type: sodalite.nodes.batch.Container.JobExecution
+      properties:
+        job_name: "batch-job-1"
+        wall_time_limit: "12:00:00"
+        node_count: 1
+        core_count: 40
+        request_gpus: 1
+        queue: "ssd"
+        standard_output_file: "batch-job-1.out"
+        standard_error_file: "batch-job-1.err"
+        combine_stdout_stderr: true
+        copy_environment: true
+        request_event_notification: "abe"
+        email_address: jesus.2.ramos@atos.net
+        workspace: ~/batch-app
+        # from IaCBuilder
+        content: "#PBS -S /bin/bash\n## START OF HEADER ## \n#PBS -N batch-job-1\n\
+          #PBS -q ssd\n#PBS -l walltime=12:00:00 \n#PBS -l nodes=1:gpus=1:ssd\n#PBS\
+          \ -l procs=40\n#PBS -o batch-job-1.out\n#PBS -e batch-job-1.err\n\
+          #PBS -j oe\n#PBS -V \n#PBS -m abe\n#PBS -M jesus.2.ramos@atos.net\n## END OF HEADER\
+          \ ## \ncd $PBS_O_WORKDIR\nexport PATH=$PBS_O_WORKDIR:$PATH\n\nsleep 20 && echo 'some-output'\n"
+      attributes:
+        env:
+          SOME_VAR: "SOME_VALUE"
+      requirements:
+        - application: batch-app-1
+        - runtime: batch-app-runtime-hpc
+        - host: hlrs-testbed
+
+    batch-app-2:
+      type: sodalite.nodes.batch.Container.Application
+      # optimization: ai_training.tensor_flow # from AADM, comes as JSON-string to IaC Builder
+      properties:
+        app_tag: "batch-app-2"
+        app_type: "python"
+        executable: "python3 resnet/resnet_imagenet_main.py"
+        arguments: "--data_dir=/mnt/nfs/home/karthee/AI/data/tf_records/train/ -batch_size=96 --train_epochs=3 --train_steps=10 --use_synthetic_data=false"
+        container_runtime: "docker://modakopt/modak:tensorflow-2.1-gpu-src" # default container runtime. Might be substituted by IaCBuilder based on optimization
+        # container_runtime: "private://cadt:1.0.0" # default container runtime for private registry. Might be substituted based on optimization
+      requirements:
+        - runtime: batch-app-runtime-hpc
+        - host: hlrs-testbed
+
+    batch-job-2:
+      type: sodalite.nodes.batch.Container.JobExecution
+      properties:
+        job_name: "batch-job-2"
+        wall_time_limit: "12:00:00"
+        node_count: 1
+        core_count: 40
+        request_gpus: 1
+        queue: "ssd"
+        standard_output_file: "batch-job-2.out"
+        standard_error_file: "batch-job-2.err"
+        combine_stdout_stderr: true
+        copy_environment: true
+        request_event_notification: "abe"
+        email_address: jesus.2.ramos@atos.net
+        workspace: ~/batch-app
+        # from IaCBuilder
+        content: "#PBS -S /bin/bash\n## START OF HEADER ## \n#PBS -N batch-job-2\n\
+          #PBS -q ssd\n#PBS -l walltime=12:00:00 \n#PBS -l nodes=1:gpus=1:ssd\n#PBS\
+          \ -l procs=40\n#PBS -o batch-job-2.out\n#PBS -e batch-job-2.err\n\
+          #PBS -j oe\n#PBS -V \n#PBS -m abe\n#PBS -M jesus.2.ramos@atos.net\n## END OF HEADER\
+          \ ## \ncd $PBS_O_WORKDIR\nexport PATH=$PBS_O_WORKDIR:$PATH\n\nsleep 20 && echo 'some-output'\n"
+      attributes:
+        env:
+          SOME_VAR: "SOME_VALUE"
+      requirements:
+        - application: batch-app-2
+        - runtime: batch-app-runtime-hpc
+        - host: hlrs-testbed
+
+### job workflow
+    workflow-elem-1:
+      type: sodalite.nodes.workflow.Job
+      requirements:
+        - execution: batch-job-1
+        - host: hlrs-testbed
+
+    workflow-elem-result-1:
+      type: sodalite.nodes.workflow.Result
+      requirements:
+        - job: workflow-elem-1
+        - host: hlrs-testbed
+
+    workflow-elem-2:
+      type: sodalite.nodes.workflow.Job
+      requirements:
+        - execution: batch-job-2
+        - host: hlrs-testbed
+        - dependency: workflow-elem-result-1
+
+    workflow-elem-result-2:
+      type: sodalite.nodes.workflow.Result
+      requirements:
+        - job: workflow-elem-2
+        - host: hlrs-testbed


### PR DESCRIPTION
Added hpc exporter collector creation and deletion playbooks in the wm node, also added jobid registration in the collector in the job deployment playbooks.

This integrates the multitenant hpc exporter.

The HPC label has been set to be the hpc ssh host as default, but I am not sure if this is possible from the xopera standpoint. If it is not, then please choose an appropriate default value.